### PR TITLE
Fix docker build

### DIFF
--- a/deploy/docker/build.sh
+++ b/deploy/docker/build.sh
@@ -6,6 +6,7 @@ cp /hosts/stack.yaml .
 cp /hosts/*.cabal .
 cp -r /hosts/src .
 cp -r /hosts/app .
+cp -r /hosts/templates .
 cp /hosts/LICENSE .
 cp /hosts/README.md .
 stack --no-terminal setup


### PR DESCRIPTION
This PR resolves the following docker build error:

```bash
[29 of 33] Compiling ASPico.Handler.Root.Conversion ( src/ASPico/Handler/Root/Conversion.hs, .stack-work/dist/x86_64-linux-tinfo6/Cabal-1.24.2.0/build/ASPico/Handler/Root/Conversion.o )

/opt/app/src/ASPico/Handler/Root/Conversion.hs:53:8: error:
    • Exception when trying to run compile-time code:
        templates/dummy.png: openBinaryFile: does not exist (No such file or directory)
      Code: pngContent
    • In the untyped splice: $pngContent
```